### PR TITLE
fix(deps): bump aiohttp to 3.13.3 (CVE-2025-69223 zip bomb)

### DIFF
--- a/requirements-prod.txt
+++ b/requirements-prod.txt
@@ -2,7 +2,7 @@ fastapi>=0.115.5
 uvicorn>=0.32.1
 python-dotenv==1.0.0
 requests>=2.32.3
-aiohttp>=3.10.11
+aiohttp>=3.13.3
 groq==0.4.1
 pydantic==2.6.0
 redis==5.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ fastapi==0.115.5
 uvicorn==0.32.1
 python-dotenv==1.0.0
 requests==2.32.3
-aiohttp==3.10.11
+aiohttp==3.13.3
 groq==0.24.0
 pydantic==2.11.3
 redis==5.0.1


### PR DESCRIPTION
## Summary
Bumps aiohttp to the patched version for **CVE-2025-69223** (GHSA-6mq8-rvhq-8wgg, High severity): aiohttp's HTTP parser `auto_decompress` feature is vulnerable to a zip bomb DoS — a crafted compressed request can exhaust host memory.

Affected: aiohttp `<= 3.13.2` ([advisory](https://github.com/advisories/GHSA-6mq8-rvhq-8wgg) · [NVD](https://nvd.nist.gov/vuln/detail/CVE-2025-69223)). Fixed in `3.13.3` ([patch](https://github.com/aio-libs/aiohttp/commit/2b920c39002cee0ec5b402581779bbaaf7c9138a)).

## Changes
| File | Before | After |
|---|---|---|
| requirements.txt | `aiohttp==3.10.11` | `aiohttp==3.13.3` |
| requirements-prod.txt | `aiohttp>=3.10.11` | `aiohttp>=3.13.3` |

The fix adds a `max_length` limit to the decompressor and raises `DecompressSizeError` when exceeded, preventing memory exhaustion.

Addresses the GitHub security alert on `requirements.txt`.