### PR TITLE
fix #2: Make simulation fully responsive and mobile-friendly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,11 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
       - name: Run save/resume regression suite
-        run: npx playwright test tests-e2e/save-resume.spec.js --reporter=line
+        run: npx playwright test tests-e2e/save-resume.spec.js --project=chromium --reporter=line
+        env:
+          CI: true
+      - name: Run mobile regression suite
+        run: npx playwright test tests-e2e/mobile.spec.js --project=mobile-chrome --reporter=line
         env:
           CI: true
       - name: Upload Playwright report

--- a/pages/simulation.jsx
+++ b/pages/simulation.jsx
@@ -557,6 +557,7 @@ export default function SimulationPage({ initialScenario }) {
           width: "100%",
           maxHeight: "90vh",
           overflowY: "auto",
+          WebkitOverflowScrolling: "touch",
           backgroundColor: "#1a1a1a",
           border: "3px solid #00ff00",
           borderRadius: "10px",
@@ -586,12 +587,8 @@ export default function SimulationPage({ initialScenario }) {
                 autoPlay
                 loop
                 muted
-                style={{
-                  width: "400px",
-                  height: "225px",
-                  borderRadius: "5px",
-                  border: "2px solid #444",
-                }}
+                playsInline
+                className="sim-conclusion-video"
               />
             </div>
           )}
@@ -702,6 +699,7 @@ export default function SimulationPage({ initialScenario }) {
 
       <Head>
         <title>Simulation Arcade</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet" />
         <style>{`
           body, html {
@@ -712,6 +710,57 @@ export default function SimulationPage({ initialScenario }) {
           }
           * {
             box-sizing: border-box;
+          }
+          .sim-content-area {
+            position: relative;
+            width: 80%;
+            margin: 20px auto;
+          }
+          .sim-content-grid {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 15px;
+            height: 500px;
+            overflow: hidden;
+          }
+          .sim-media-section {
+            height: 100%;
+          }
+          .sim-chat-section {
+            height: 100%;
+          }
+          .sim-touch-btn {
+            touch-action: manipulation;
+          }
+          .sim-conclusion-video {
+            width: 400px;
+            height: 225px;
+            border-radius: 5px;
+            border: 2px solid #444;
+          }
+          @media (max-width: 768px) {
+            .sim-content-area {
+              width: 95% !important;
+              padding: 10px !important;
+              margin: 10px auto !important;
+            }
+            .sim-content-grid {
+              grid-template-columns: 1fr !important;
+              height: auto !important;
+              overflow: visible !important;
+            }
+            .sim-media-section {
+              height: 220px !important;
+              min-height: 180px;
+            }
+            .sim-chat-section {
+              height: 260px !important;
+            }
+            .sim-conclusion-video {
+              width: 100% !important;
+              height: auto !important;
+              max-width: 400px;
+            }
           }
         `}</style>
       </Head>
@@ -777,7 +826,7 @@ export default function SimulationPage({ initialScenario }) {
               </div>
             )}
             <button
-              className="begin-button"
+              className="begin-button sim-touch-btn"
             onClick={() => {
               clearSavedSimulation();
               setSimulationStarted(true);
@@ -799,6 +848,7 @@ export default function SimulationPage({ initialScenario }) {
               textTransform: "uppercase",
               opacity: isLoading ? 0.5 : 1,
               transition: "all 0.3s ease",
+              minHeight: "44px",
             }}
           >
             {isLoading ? "Loading..." : "Begin"}
@@ -806,6 +856,7 @@ export default function SimulationPage({ initialScenario }) {
             {savedSimulation && (
               <button
                 data-testid="continue-simulation"
+                className="sim-touch-btn"
                 onClick={resumeSimulation}
                 disabled={isLoading}
                 style={{
@@ -823,6 +874,7 @@ export default function SimulationPage({ initialScenario }) {
                   opacity: isLoading ? 0.5 : 1,
                   transition: "all 0.3s ease",
                   boxShadow: "0 0 8px rgba(0, 204, 255, 0.4)",
+                  minHeight: "44px",
                 }}
               >
                 Continue Simulation
@@ -834,10 +886,7 @@ export default function SimulationPage({ initialScenario }) {
 
       {/* Arcade Screen Content Area - Show after simulation starts */}
       {simulationStarted && (
-      <div style={{
-        position: "relative",
-        width: "80%",
-        margin: "20px auto",
+      <div className="sim-content-area" style={{
         backgroundColor: "rgba(0, 0, 0, 0.8)",
         border: "5px solid #333",
         borderRadius: "10px",
@@ -859,15 +908,9 @@ export default function SimulationPage({ initialScenario }) {
         </div>
 
         {/* Content Grid */}
-        <div style={{
-          display: "grid",
-          gridTemplateColumns: "1fr 1fr",
-          gap: "15px",
-          height: "500px",  // Fixed height to prevent growing
-          overflow: "hidden",
-        }}>
+        <div className="sim-content-grid" style={{ gap: "15px" }}>
           {/* Media Section - Now uses MediaHandler */}
-          <div style={{
+          <div className="sim-media-section" style={{
             backgroundColor: "#111",
             border: "2px solid #444",
             borderRadius: "5px",
@@ -875,7 +918,6 @@ export default function SimulationPage({ initialScenario }) {
             display: "flex",
             justifyContent: "center",
             alignItems: "center",
-            height: "100%",
             minHeight: '200px',
             position: 'relative',
           }}>
@@ -907,8 +949,7 @@ export default function SimulationPage({ initialScenario }) {
           </div>
 
           {/* Chat Section - Single window matching video height */}
-          <div style={{
-            height: "100%",
+          <div className="sim-chat-section" style={{
             backgroundColor: "#1a1a1a",
             border: "2px solid #444",
             padding: "10px",
@@ -920,6 +961,7 @@ export default function SimulationPage({ initialScenario }) {
             justifyContent: isLoading && history.length === 0 ? "center" : "flex-start",
             alignItems: isLoading && history.length === 0 ? "center" : "stretch",
             fontFamily: '"Press Start 2P", cursive',
+            WebkitOverflowScrolling: "touch",
           }}>
             <div ref={chatEndRef} />
             {isLoading && history.length === 0 ? (
@@ -980,9 +1022,11 @@ export default function SimulationPage({ initialScenario }) {
               color: "#fff",
               fontFamily: 'inherit',
               fontSize: "0.8em",
+              minHeight: "44px",
+              touchAction: "manipulation",
             }}
           />
-          <button type="submit" disabled={isLoading || (submissionCount >= maxTurns && !showConclusion) || !simulationId} style={{
+          <button type="submit" className="sim-touch-btn" disabled={isLoading || (submissionCount >= maxTurns && !showConclusion) || !simulationId} style={{
             padding: "10px 15px",
             borderRadius: "5px",
             border: "none",
@@ -991,6 +1035,7 @@ export default function SimulationPage({ initialScenario }) {
             cursor: "pointer",
             fontFamily: 'inherit',
             fontSize: "0.8em",
+            minHeight: "44px",
             opacity: (isLoading || (submissionCount >= maxTurns && !showConclusion) || !simulationId) ? 0.5 : 1,
           }}>
             Send

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -31,6 +31,10 @@ export default defineConfig({
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
     },
+    {
+      name: 'mobile-chrome',
+      use: { ...devices['Pixel 7'] },
+    },
   ],
 
   /* Run the production server before tests in CI; reuse local server when already running */

--- a/tests-e2e/mobile.spec.js
+++ b/tests-e2e/mobile.spec.js
@@ -1,0 +1,150 @@
+import { test, expect } from '@playwright/test';
+
+const STORAGE_KEY = 'save-the-world:sim-state';
+
+const MOCK_SAVE = {
+  simulationId: 'test-mobile-sim',
+  turn: 1,
+  maxTurns: 3,
+  submissionCount: 1,
+  history: [
+    { role: 'assistant', content: 'A giant wave approaches the coastline...' },
+    { role: 'user', content: 'Build a seawall.' },
+  ],
+  currentVideoUrls: [],
+  currentAudioUrl: null,
+  scenarioGenerated: true,
+  videosGenerated: false,
+  audioGenerated: false,
+  savedAt: Date.now(),
+};
+
+// Mock with video URLs so MediaHandler renders <video> elements (not the "no media" early-return)
+const MOCK_SAVE_WITH_MEDIA = {
+  ...MOCK_SAVE,
+  simulationId: 'test-mobile-media-sim',
+  currentVideoUrls: ['/fake-video.mp4'],
+  videosGenerated: true,
+};
+
+test.describe('Mobile Responsiveness', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript((key) => {
+      localStorage.removeItem(key);
+    }, STORAGE_KEY);
+  });
+
+  test('viewport meta tag is present', async ({ page }) => {
+    await page.goto('/simulation');
+    const viewport = await page.$eval(
+      'meta[name="viewport"]',
+      (el) => el.getAttribute('content')
+    );
+    expect(viewport).toContain('width=device-width');
+    expect(viewport).toContain('initial-scale=1');
+  });
+
+  test('no horizontal overflow on mobile viewport', async ({ page }) => {
+    await page.goto('/simulation');
+    const bodyWidth = await page.evaluate(() => document.body.scrollWidth);
+    const viewportWidth = await page.evaluate(() => window.innerWidth);
+    expect(bodyWidth).toBeLessThanOrEqual(viewportWidth + 2); // allow 2px rounding
+  });
+
+  test('Begin button has accessible touch target size', async ({ page }) => {
+    await page.goto('/simulation');
+    const btn = page.locator('button:has-text("Begin"), button:has-text("Loading")').first();
+    await expect(btn).toBeVisible({ timeout: 5000 });
+    const box = await btn.boundingBox();
+    expect(box.height).toBeGreaterThanOrEqual(44);
+  });
+
+  test('Continue button has accessible touch target size when save exists', async ({ page }) => {
+    await page.addInitScript(
+      ({ key, value }) => { localStorage.setItem(key, JSON.stringify(value)); },
+      { key: STORAGE_KEY, value: MOCK_SAVE }
+    );
+    await page.goto('/simulation');
+    const continueBtn = page.getByTestId('continue-simulation');
+    await expect(continueBtn).toBeVisible({ timeout: 5000 });
+    const box = await continueBtn.boundingBox();
+    expect(box.height).toBeGreaterThanOrEqual(44);
+  });
+
+  test('text is readable — font size does not drop below 12px on start screen', async ({ page }) => {
+    await page.goto('/simulation');
+    const btn = page.locator('button:has-text("Begin"), button:has-text("Loading")').first();
+    await expect(btn).toBeVisible({ timeout: 5000 });
+    const fontSize = await btn.evaluate((el) =>
+      parseFloat(window.getComputedStyle(el).fontSize)
+    );
+    // Press Start 2P 0.8em at 16px base = ~12.8px; allow down to 10px for safety
+    expect(fontSize).toBeGreaterThanOrEqual(10);
+  });
+
+  test('simulation view renders in single-column on mobile and allows scroll', async ({ page, viewport }) => {
+    // Only meaningful on mobile viewports (≤768px)
+    test.skip(!viewport || viewport.width > 768, 'Single-column layout check only applies to mobile viewports');
+
+    await page.addInitScript(
+      ({ key, value }) => { localStorage.setItem(key, JSON.stringify(value)); },
+      { key: STORAGE_KEY, value: MOCK_SAVE }
+    );
+    await page.goto('/simulation');
+    const continueBtn = page.getByTestId('continue-simulation');
+    await expect(continueBtn).toBeVisible({ timeout: 5000 });
+    await continueBtn.click();
+
+    // Wait for simulation view
+    await page.waitForSelector('.sim-content-grid', { timeout: 5000 });
+
+    // On mobile viewport the grid should stack: columns resolve to a single track
+    const cols = await page.$eval('.sim-content-grid', (el) =>
+      window.getComputedStyle(el).gridTemplateColumns
+    );
+    // Single-column: one value (not two), e.g. "390px" not "195px 195px"
+    const colCount = cols.trim().split(/\s+/).length;
+    expect(colCount).toBe(1);
+  });
+
+  test('video elements have playsInline for mobile browser compatibility', async ({ page }) => {
+    // Route the fake video URL to hang (never resolve) so MediaHandler stays in loading
+    // state with <video> elements in DOM long enough to assert on their attributes.
+    await page.route('**/fake-video.mp4', () => { /* intentionally never fulfilled */ });
+
+    // Use mock with video URLs so MediaHandler renders <video> elements (not the "no media" early-return)
+    await page.addInitScript(
+      ({ key, value }) => { localStorage.setItem(key, JSON.stringify(value)); },
+      { key: STORAGE_KEY, value: MOCK_SAVE_WITH_MEDIA }
+    );
+    await page.goto('/simulation');
+    const continueBtn = page.getByTestId('continue-simulation');
+    await expect(continueBtn).toBeVisible({ timeout: 5000 });
+    await continueBtn.click();
+
+    // Wait for video element to be in DOM (route keeps request pending so element stays)
+    const videoLocator = page.locator('video').first();
+    await expect(videoLocator).toBeAttached({ timeout: 8000 });
+    const hasPlaysinline = await videoLocator.evaluate((el) => el.hasAttribute('playsinline'));
+    expect(hasPlaysinline).toBe(true);
+  });
+
+  test('input and send button have accessible touch target height', async ({ page }) => {
+    await page.addInitScript(
+      ({ key, value }) => { localStorage.setItem(key, JSON.stringify(value)); },
+      { key: STORAGE_KEY, value: MOCK_SAVE }
+    );
+    await page.goto('/simulation');
+    const continueBtn = page.getByTestId('continue-simulation');
+    await expect(continueBtn).toBeVisible({ timeout: 5000 });
+    await continueBtn.click();
+
+    await page.waitForSelector('input[type="text"]', { timeout: 5000 });
+    const inputBox = await page.locator('input[type="text"]').boundingBox();
+    const sendBtn = page.locator('button[type="submit"]');
+    const sendBox = await sendBtn.boundingBox();
+
+    expect(inputBox.height).toBeGreaterThanOrEqual(44);
+    expect(sendBox.height).toBeGreaterThanOrEqual(44);
+  });
+});


### PR DESCRIPTION
Closes #2

## Summary
Make the simulation fully responsive and mobile-friendly.

- Viewport meta tag (`width=device-width, initial-scale=1`) on the simulation page
- `@media (max-width: 768px)` layout: single-column grid, fluid content area, video scales to 100% width
- Touch-friendly controls: 44px+ min-height on Begin / Continue / input / Send, `touch-action: manipulation` to suppress double-tap zoom delay
- `-webkit-overflow-scrolling: touch` on scroll areas for momentum scrolling
- `playsInline` on the conclusion video for iOS Safari compatibility
- New `mobile-chrome` Playwright project (Pixel 7) + `tests-e2e/mobile.spec.js` regression suite (8 tests: viewport meta, no horizontal overflow, touch target sizes, single-column layout, playsInline, readable text)

## CI
- `regressions` job now runs the mobile spec on the `mobile-chrome` project alongside the save/resume spec on `chromium`

## Verification
- Python unit tests: 14 passed, 1 skipped, 8 deselected (pre-existing deselects for #13/#22/#24)
- `npm run build`: pass
- `tests-e2e/mobile.spec.js --project=mobile-chrome`: 8/8 passed
- `tests-e2e/save-resume.spec.js --project=chromium`: 6/6 passed
