### PR TITLE
ci: add concurrency cancel-in-progress guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unit-tests:
     name: Unit tests (Python)


### PR DESCRIPTION
Adds the fleet-standard concurrency guard (group: ci-${{ github.workflow }}-${{ github.ref }}, cancel-in-progress: true) so a second push to a ref cancels the superseded run instead of racing it. Same guard already on lit/amuseical/Atlas-AI/explore-the-universe ci.yml.

Closes nothing — CI hardening per the 2026-08-06 fail-closed CI directive.