### PR TITLE
fix #3: Add Basic Analytics Dashboard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,10 @@ jobs:
         run: npx playwright test tests-e2e/mobile.spec.js --project=mobile-chrome --reporter=line
         env:
           CI: true
+      - name: Run analytics dashboard regression suite
+        run: npx playwright test tests-e2e/analytics.spec.js --project=chromium --reporter=line
+        env:
+          CI: true
       - name: Upload Playwright report
         if: always()
         uses: actions/upload-artifact@v4

--- a/api/app.py
+++ b/api/app.py
@@ -17,6 +17,7 @@ from services.llm_service import LLMService
 from services.state_service import StateService
 from services.media_service import MediaService
 from services.simulation_service import SimulationService
+from services.analytics_service import AnalyticsService
 from api.routes import router
 
 # Load environment variables
@@ -148,7 +149,10 @@ def init_services():
         
         # Attach simulation service to router
         router.simulation_service = simulation_service
-        
+
+        # Attach analytics service to router (derives metrics from state_service)
+        router.analytics_service = AnalyticsService(state_service)
+
         logger.info("Services initialized successfully")
     except Exception as e:
         logger.error(f"Error initializing services: {str(e)}")

--- a/api/routes.py
+++ b/api/routes.py
@@ -5,13 +5,15 @@ This module defines the FastAPI routes for the simulation API.
 """
 
 from fastapi import APIRouter, HTTPException, Depends, WebSocket, WebSocketDisconnect
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 from typing import Dict, Any, List, Optional
+import io
 import logging
 import json
 from models.simulation import SimulationRequest, UserResponseRequest, SimulationState, DateTimeEncoder, DeveloperModeRequest
 
 from services.simulation_service import SimulationService
+from services.analytics_service import AnalyticsService
 
 logger = logging.getLogger(__name__)
 
@@ -227,6 +229,36 @@ async def delete_simulation(
     if not result:
         raise HTTPException(status_code=404, detail=f"Simulation not found: {simulation_id}")
     return None
+
+async def get_analytics_service() -> AnalyticsService:
+    return router.analytics_service
+
+
+@router.get("/analytics/summary")
+async def get_analytics_summary(
+    analytics_service: AnalyticsService = Depends(get_analytics_service),
+):
+    return analytics_service.get_summary()
+
+
+@router.get("/analytics/trends")
+async def get_analytics_trends(
+    analytics_service: AnalyticsService = Depends(get_analytics_service),
+):
+    return analytics_service.get_trends()
+
+
+@router.get("/analytics/export")
+async def export_analytics_csv(
+    analytics_service: AnalyticsService = Depends(get_analytics_service),
+):
+    csv_data = analytics_service.export_csv()
+    return StreamingResponse(
+        io.StringIO(csv_data),
+        media_type="text/csv",
+        headers={"Content-Disposition": "attachment; filename=analytics.csv"},
+    )
+
 
 @router.websocket("/ws/simulations/{simulation_id}")
 async def websocket_endpoint(

--- a/pages/analytics.jsx
+++ b/pages/analytics.jsx
@@ -1,0 +1,192 @@
+import React, { useState, useEffect } from "react";
+import Head from "next/head";
+
+const BACKEND_DEFAULT = "http://localhost:8000";
+
+function MetricCard({ label, value, testId }) {
+  return (
+    <div
+      data-testid={testId}
+      style={{
+        background: "#1a1a2e", border: "1px solid #333", borderRadius: 8,
+        padding: "20px 24px", minWidth: 160, textAlign: "center",
+      }}
+    >
+      <div data-testid={testId && `${testId}-value`} style={{ fontSize: 28, fontWeight: 700, color: "#a78bfa" }}>{value}</div>
+      <div style={{ fontSize: 13, color: "#9ca3af", marginTop: 6 }}>{label}</div>
+    </div>
+  );
+}
+
+function TrendChart({ trends }) {
+  if (!trends || trends.length === 0) {
+    return <p style={{ color: "#6b7280" }}>No trend data yet.</p>;
+  }
+
+  const maxStarted = Math.max(...trends.map(t => t.simulations_started), 1);
+  const barWidth = Math.min(60, Math.floor(560 / trends.length) - 8);
+  const chartH = 160;
+
+  return (
+    <div style={{ overflowX: "auto" }}>
+      <svg
+        aria-label="Simulations trend chart"
+        width={Math.max(600, trends.length * (barWidth + 8) + 40)}
+        height={chartH + 60}
+        style={{ display: "block" }}
+      >
+        {trends.map((t, i) => {
+          const startedH = Math.max(4, Math.round((t.simulations_started / maxStarted) * chartH));
+          const completedH = Math.max(
+            t.simulations_completed > 0 ? 4 : 0,
+            Math.round((t.simulations_completed / maxStarted) * chartH),
+          );
+          const x = 20 + i * (barWidth + 8);
+          return (
+            <g key={t.date}>
+              <rect
+                x={x} y={chartH - startedH}
+                width={barWidth} height={startedH}
+                fill="#6366f1" rx={3}
+                aria-label={`${t.date}: ${t.simulations_started} started`}
+              />
+              <rect
+                x={x} y={chartH - completedH}
+                width={barWidth} height={completedH}
+                fill="#a78bfa" rx={3}
+                aria-label={`${t.date}: ${t.simulations_completed} completed`}
+              />
+              <text
+                x={x + barWidth / 2} y={chartH + 16}
+                textAnchor="middle" fontSize={10} fill="#9ca3af"
+              >
+                {t.date.slice(5)}
+              </text>
+              <text
+                x={x + barWidth / 2} y={chartH - startedH - 4}
+                textAnchor="middle" fontSize={10} fill="#e5e7eb"
+              >
+                {t.simulations_started}
+              </text>
+            </g>
+          );
+        })}
+      </svg>
+      <div style={{ display: "flex", gap: 16, marginTop: 8, fontSize: 12, color: "#9ca3af" }}>
+        <span><span style={{ background: "#6366f1", display: "inline-block", width: 12, height: 12, borderRadius: 2, marginRight: 4 }} />Started</span>
+        <span><span style={{ background: "#a78bfa", display: "inline-block", width: 12, height: 12, borderRadius: 2, marginRight: 4 }} />Completed</span>
+      </div>
+    </div>
+  );
+}
+
+export default function AnalyticsDashboard() {
+  const [summary, setSummary] = useState(null);
+  const [trends, setTrends] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [backendUrl, setBackendUrl] = useState(BACKEND_DEFAULT);
+
+  useEffect(() => {
+    async function discoverBackend() {
+      try {
+        const res = await fetch("/api/backend-port");
+        if (res.ok) {
+          const { port } = await res.json();
+          setBackendUrl(`http://localhost:${port}`);
+        }
+      } catch (_) {}
+    }
+    discoverBackend();
+  }, []);
+
+  useEffect(() => {
+    if (!backendUrl) return;
+    async function fetchAnalytics() {
+      setLoading(true);
+      setError(null);
+      try {
+        const [sumRes, trendRes] = await Promise.all([
+          fetch(`${backendUrl}/api/analytics/summary`),
+          fetch(`${backendUrl}/api/analytics/trends`),
+        ]);
+        if (!sumRes.ok || !trendRes.ok) throw new Error("Failed to load analytics");
+        const [sumData, trendData] = await Promise.all([sumRes.json(), trendRes.json()]);
+        setSummary(sumData);
+        setTrends(trendData);
+      } catch (e) {
+        setError(e.message);
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchAnalytics();
+  }, [backendUrl]);
+
+  function handleExport() {
+    window.location.href = `${backendUrl}/api/analytics/export`;
+  }
+
+  const pageStyle = {
+    minHeight: "100vh", background: "#0f0f1a", color: "#e5e7eb",
+    fontFamily: "system-ui, -apple-system, sans-serif", padding: "40px 32px",
+  };
+
+  return (
+    <>
+      <Head>
+        <title>Analytics — Save the World</title>
+      </Head>
+      <div style={pageStyle}>
+        <div style={{ maxWidth: 860, margin: "0 auto" }}>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 32 }}>
+            <div>
+              <h1 style={{ margin: 0, fontSize: 28, fontWeight: 700 }}>Analytics Dashboard</h1>
+              <p style={{ margin: "6px 0 0", color: "#9ca3af", fontSize: 14 }}>
+                Simulation engagement metrics
+              </p>
+            </div>
+            <button
+              onClick={handleExport}
+              data-testid="export-csv-btn"
+              style={{
+                background: "#6366f1", color: "#fff", border: "none",
+                borderRadius: 6, padding: "10px 20px", cursor: "pointer",
+                fontSize: 14, fontWeight: 600,
+              }}
+            >
+              Export CSV
+            </button>
+          </div>
+
+          {loading && <p style={{ color: "#9ca3af" }}>Loading analytics…</p>}
+          {error && <p style={{ color: "#ef4444" }}>Error: {error}</p>}
+
+          {summary && (
+            <>
+              <div style={{ display: "flex", flexWrap: "wrap", gap: 16, marginBottom: 40 }}>
+                <MetricCard label="Total Simulations" value={summary.total_simulations} testId="metric-total" />
+                <MetricCard label="Completed" value={summary.completed_simulations} testId="metric-completed" />
+                <MetricCard label="Completion Rate" value={`${summary.completion_rate}%`} testId="metric-completion-rate" />
+                <MetricCard label="Avg Turns" value={summary.avg_turns_per_simulation} testId="metric-avg-turns" />
+                <MetricCard label="Total Responses" value={summary.total_user_responses} testId="metric-total-responses" />
+                <MetricCard label="Avg Response Length" value={`${summary.avg_response_length} chars`} testId="metric-avg-length" />
+              </div>
+
+              <div style={{
+                background: "#1a1a2e", border: "1px solid #333", borderRadius: 8, padding: "24px",
+              }}>
+                <h2 style={{ margin: "0 0 20px", fontSize: 18, fontWeight: 600 }}>Trends Over Time</h2>
+                <TrendChart trends={trends} />
+              </div>
+            </>
+          )}
+
+          <div style={{ marginTop: 24 }}>
+            <a href="/" style={{ color: "#6366f1", fontSize: 13 }}>← Back to Simulation</a>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/pages/simulation.jsx
+++ b/pages/simulation.jsx
@@ -880,6 +880,26 @@ export default function SimulationPage({ initialScenario }) {
                 Continue Simulation
               </button>
             )}
+            <a
+              href="/analytics"
+              data-testid="analytics-link"
+              style={{
+                padding: "8px 16px",
+                fontSize: "0.55em",
+                fontFamily: '"Press Start 2P", cursive',
+                color: "#9ca3af",
+                border: "1px solid #555",
+                borderRadius: "6px",
+                textDecoration: "none",
+                textTransform: "uppercase",
+                minHeight: "44px",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+              }}
+            >
+              Analytics Dashboard
+            </a>
           </div>
         </>
       )}

--- a/services/analytics_service.py
+++ b/services/analytics_service.py
@@ -1,0 +1,105 @@
+"""
+Analytics Service Module
+
+Derives simulation analytics from the existing StateService store.
+No separate persistence — metrics are computed on demand from live state.
+
+Metric definitions (issue #3):
+  - total_simulations: count of all known simulations
+  - completed_simulations: count where is_complete=True
+  - completion_rate: completed / total * 100 (0.0 when no simulations)
+  - avg_turns_per_simulation: mean of len(sim.turns) across all simulations
+  - total_user_responses: total UserResponse objects across all turns
+  - avg_response_length: mean char length of all UserResponse.response_text values (0.0 if none)
+  - trend data: daily counts of simulations started/completed keyed by created_at.date()
+"""
+import csv
+import io
+from collections import defaultdict
+from typing import Any
+
+from services.state_service import StateService
+
+
+class AnalyticsService:
+    def __init__(self, state_service: StateService) -> None:
+        self.state_service = state_service
+
+    def _all_simulations(self):
+        return self.state_service.get_all_simulations()
+
+    def get_summary(self) -> dict[str, Any]:
+        sims = self._all_simulations()
+        total = len(sims)
+        completed = sum(1 for s in sims if s.is_complete)
+        completion_rate = round(completed / total * 100, 2) if total else 0.0
+
+        all_responses = [
+            turn.user_response
+            for sim in sims
+            for turn in sim.turns
+            if turn.user_response is not None
+        ]
+        total_responses = len(all_responses)
+        total_turns = sum(len(s.turns) for s in sims)
+        avg_turns = round(total_turns / total, 2) if total else 0.0
+        avg_response_length = (
+            round(sum(len(r.response_text) for r in all_responses) / total_responses, 2)
+            if total_responses else 0.0
+        )
+
+        return {
+            "total_simulations": total,
+            "completed_simulations": completed,
+            "completion_rate": completion_rate,
+            "avg_turns_per_simulation": avg_turns,
+            "total_user_responses": total_responses,
+            "avg_response_length": avg_response_length,
+        }
+
+    def get_trends(self) -> list[dict[str, Any]]:
+        sims = self._all_simulations()
+        started: dict[str, int] = defaultdict(int)
+        completed_by_day: dict[str, int] = defaultdict(int)
+
+        for sim in sims:
+            day = sim.created_at.strftime("%Y-%m-%d")
+            started[day] += 1
+            if sim.is_complete:
+                completed_by_day[day] += 1
+
+        return [
+            {
+                "date": day,
+                "simulations_started": started[day],
+                "simulations_completed": completed_by_day.get(day, 0),
+            }
+            for day in sorted(started)
+        ]
+
+    def export_csv(self) -> str:
+        sims = self._all_simulations()
+        output = io.StringIO()
+        fieldnames = [
+            "simulation_id", "created_at", "is_complete",
+            "total_turns", "total_responses", "avg_response_length",
+        ]
+        writer = csv.DictWriter(output, fieldnames=fieldnames)
+        writer.writeheader()
+        for sim in sims:
+            responses = [
+                t.user_response for t in sim.turns if t.user_response is not None
+            ]
+            avg_len = (
+                round(sum(len(r.response_text) for r in responses) / len(responses), 2)
+                if responses else 0.0
+            )
+            writer.writerow({
+                "simulation_id": sim.simulation_id,
+                "created_at": sim.created_at.isoformat(),
+                "is_complete": str(sim.is_complete),
+                "total_turns": len(sim.turns),
+                "total_responses": len(responses),
+                "avg_response_length": avg_len,
+            })
+        return output.getvalue()

--- a/tests-e2e/analytics.spec.js
+++ b/tests-e2e/analytics.spec.js
@@ -1,0 +1,129 @@
+/**
+ * Analytics Dashboard regression suite (issue #3).
+ *
+ * Hermetic — backend is mocked via page.route() so the spec passes without a
+ * running Python server.  Mirrors the pattern established for save-resume.spec.js.
+ */
+import { test, expect } from '@playwright/test';
+
+const MOCK_SUMMARY = {
+  total_simulations: 5,
+  completed_simulations: 3,
+  completion_rate: 60.0,
+  avg_turns_per_simulation: 2.4,
+  total_user_responses: 12,
+  avg_response_length: 42.5,
+};
+
+const MOCK_TRENDS = [
+  { date: '2026-08-06', simulations_started: 2, simulations_completed: 1 },
+  { date: '2026-08-07', simulations_started: 3, simulations_completed: 2 },
+];
+
+test.describe('Analytics Dashboard', () => {
+  test.beforeEach(async ({ page }) => {
+    // Mock the backend-port discovery endpoint (Next.js API route)
+    await page.route('**/api/backend-port', (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ port: 8000 }) }),
+    );
+    // Mock analytics summary
+    await page.route('**/api/analytics/summary', (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(MOCK_SUMMARY) }),
+    );
+    // Mock analytics trends
+    await page.route('**/api/analytics/trends', (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(MOCK_TRENDS) }),
+    );
+    await page.goto('/analytics');
+  });
+
+  test('page loads and shows heading', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: /Analytics Dashboard/i })).toBeVisible();
+  });
+
+  test('displays total simulations metric', async ({ page }) => {
+    await expect(page.getByTestId('metric-total-value')).toHaveText('5');
+    await expect(page.getByText('Total Simulations')).toBeVisible();
+  });
+
+  test('displays completion rate', async ({ page }) => {
+    await expect(page.getByTestId('metric-completion-rate-value')).toHaveText('60%');
+    await expect(page.getByText('Completion Rate')).toBeVisible();
+  });
+
+  test('displays completed simulations count', async ({ page }) => {
+    await expect(page.getByTestId('metric-completed-value')).toHaveText('3');
+    await expect(page.getByTestId('metric-completed')).toContainText('Completed');
+  });
+
+  test('displays avg turns metric', async ({ page }) => {
+    await expect(page.getByTestId('metric-avg-turns-value')).toHaveText('2.4');
+    await expect(page.getByText('Avg Turns')).toBeVisible();
+  });
+
+  test('shows trend chart with date labels', async ({ page }) => {
+    // Chart renders SVG with date tick labels (MM-DD format)
+    await expect(page.locator('svg[aria-label*="trend"]')).toBeVisible();
+    await expect(page.getByText('08-06')).toBeVisible();
+    await expect(page.getByText('08-07')).toBeVisible();
+  });
+
+  test('export CSV button is visible and points to export endpoint', async ({ page }) => {
+    const exportBtn = page.getByTestId('export-csv-btn');
+    await expect(exportBtn).toBeVisible();
+    await expect(exportBtn).toContainText('Export CSV');
+  });
+
+  test('back link navigates toward home', async ({ page }) => {
+    const backLink = page.getByRole('link', { name: /Back to Simulation/i });
+    await expect(backLink).toBeVisible();
+    await expect(backLink).toHaveAttribute('href', '/');
+  });
+});
+
+test.describe('Analytics Dashboard — empty state', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/api/backend-port', (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ port: 8000 }) }),
+    );
+    await page.route('**/api/analytics/summary', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          total_simulations: 0,
+          completed_simulations: 0,
+          completion_rate: 0.0,
+          avg_turns_per_simulation: 0,
+          total_user_responses: 0,
+          avg_response_length: 0.0,
+        }),
+      }),
+    );
+    await page.route('**/api/analytics/trends', (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) }),
+    );
+    await page.goto('/analytics');
+  });
+
+  test('shows zero for all metrics', async ({ page }) => {
+    await expect(page.getByText('Total Simulations')).toBeVisible();
+    // All zero values rendered
+    const zeros = page.getByText('0');
+    await expect(zeros.first()).toBeVisible();
+  });
+
+  test('shows no trend data message', async ({ page }) => {
+    await expect(page.getByText(/No trend data yet/i)).toBeVisible();
+  });
+});
+
+test.describe('Analytics Dashboard — entry point', () => {
+  test('start screen links to the analytics dashboard', async ({ page }) => {
+    // Start screen renders statically; the link must exist without a backend.
+    await page.goto('/');
+    const link = page.getByTestId('analytics-link');
+    await expect(link).toBeVisible();
+    await expect(link).toHaveAttribute('href', '/analytics');
+  });
+});

--- a/tests/unit/test_analytics_service.py
+++ b/tests/unit/test_analytics_service.py
@@ -1,0 +1,179 @@
+"""
+Unit tests for AnalyticsService (issue #3: Add Basic Analytics Dashboard).
+
+Acceptance criteria tested:
+  1. Analytics data collected per simulation (summary metrics)
+  2. Key metrics computable: completion rate, avg turns, avg response length
+  3. Trend data over time
+  4. CSV export functionality
+"""
+import io
+import csv
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock
+
+import pytest
+
+from services.analytics_service import AnalyticsService
+from models.simulation import SimulationState, SimulationTurn, UserResponse
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _make_sim(sim_id: str, is_complete: bool, turns_with_responses: int,
+              response_texts: list[str] = None, created_at: datetime = None) -> SimulationState:
+    """Build a minimal SimulationState for analytics tests."""
+    sim = SimulationState(simulation_id=sim_id)
+    sim.is_complete = is_complete
+    if created_at:
+        sim.created_at = created_at
+    for i, text in enumerate((response_texts or []) + [""] * (turns_with_responses - len(response_texts or []))):
+        turn = SimulationTurn(turn_number=i + 1)
+        if text or i < turns_with_responses:
+            turn.user_response = UserResponse(turn_number=i + 1, response_text=text or "default")
+        sim.turns.append(turn)
+    return sim
+
+
+def _make_state_service(simulations: list[SimulationState]):
+    """Return a mock StateService that returns the given simulations."""
+    mock = MagicMock()
+    mock.get_all_simulations.return_value = simulations
+    return mock
+
+
+@pytest.fixture
+def empty_service():
+    return AnalyticsService(_make_state_service([]))
+
+
+@pytest.fixture
+def populated_service():
+    now = datetime(2026, 8, 7, 12, 0, 0)
+    yesterday = now - timedelta(days=1)
+    sims = [
+        _make_sim("s1", is_complete=True, turns_with_responses=3,
+                  response_texts=["hello world", "bye", "ok"], created_at=now),
+        _make_sim("s2", is_complete=True, turns_with_responses=2,
+                  response_texts=["test response here", "another"], created_at=now),
+        _make_sim("s3", is_complete=False, turns_with_responses=1,
+                  response_texts=["short"], created_at=yesterday),
+    ]
+    return AnalyticsService(_make_state_service(sims))
+
+
+# ---------------------------------------------------------------------------
+# 1. Summary metrics
+# ---------------------------------------------------------------------------
+
+class TestSummaryMetrics:
+    def test_empty_returns_zero_totals(self, empty_service):
+        summary = empty_service.get_summary()
+        assert summary["total_simulations"] == 0
+        assert summary["completed_simulations"] == 0
+        assert summary["completion_rate"] == 0.0
+
+    def test_total_count(self, populated_service):
+        assert populated_service.get_summary()["total_simulations"] == 3
+
+    def test_completed_count(self, populated_service):
+        assert populated_service.get_summary()["completed_simulations"] == 2
+
+    def test_completion_rate(self, populated_service):
+        rate = populated_service.get_summary()["completion_rate"]
+        assert abs(rate - 66.67) < 0.1
+
+    def test_avg_turns(self, populated_service):
+        # s1=3 turns, s2=2, s3=1 → mean=2.0
+        avg = populated_service.get_summary()["avg_turns_per_simulation"]
+        assert abs(avg - 2.0) < 0.01
+
+    def test_avg_response_length(self, populated_service):
+        # responses: "hello world"=11, "bye"=3, "ok"=2,
+        #            "test response here"=18, "another"=7, "short"=5
+        # total chars = 46, count = 6 → avg ≈ 7.67
+        avg = populated_service.get_summary()["avg_response_length"]
+        assert abs(avg - 7.67) < 0.1
+
+    def test_summary_keys_present(self, populated_service):
+        summary = populated_service.get_summary()
+        required_keys = {
+            "total_simulations", "completed_simulations", "completion_rate",
+            "avg_turns_per_simulation", "avg_response_length", "total_user_responses",
+        }
+        assert required_keys.issubset(summary.keys())
+
+
+# ---------------------------------------------------------------------------
+# 2. Trend data
+# ---------------------------------------------------------------------------
+
+class TestTrendData:
+    def test_empty_trends(self, empty_service):
+        trends = empty_service.get_trends()
+        assert trends == []
+
+    def test_trends_grouped_by_day(self, populated_service):
+        trends = populated_service.get_trends()
+        dates = [t["date"] for t in trends]
+        # Two distinct dates
+        assert len(set(dates)) == 2
+
+    def test_trends_count_today(self, populated_service):
+        trends = populated_service.get_trends()
+        today_entry = next((t for t in trends if t["date"] == "2026-08-07"), None)
+        assert today_entry is not None
+        assert today_entry["simulations_started"] == 2
+
+    def test_trends_count_yesterday(self, populated_service):
+        trends = populated_service.get_trends()
+        yesterday_entry = next((t for t in trends if t["date"] == "2026-08-06"), None)
+        assert yesterday_entry is not None
+        assert yesterday_entry["simulations_started"] == 1
+
+    def test_trends_completed_count(self, populated_service):
+        trends = populated_service.get_trends()
+        today_entry = next(t for t in trends if t["date"] == "2026-08-07")
+        assert today_entry["simulations_completed"] == 2
+
+    def test_trends_sorted_ascending(self, populated_service):
+        trends = populated_service.get_trends()
+        dates = [t["date"] for t in trends]
+        assert dates == sorted(dates)
+
+
+# ---------------------------------------------------------------------------
+# 3. CSV export
+# ---------------------------------------------------------------------------
+
+class TestCSVExport:
+    def test_export_returns_string(self, populated_service):
+        csv_data = populated_service.export_csv()
+        assert isinstance(csv_data, str)
+
+    def test_export_headers(self, populated_service):
+        csv_data = populated_service.export_csv()
+        reader = csv.DictReader(io.StringIO(csv_data))
+        headers = reader.fieldnames
+        required = {"simulation_id", "created_at", "is_complete", "total_turns", "total_responses", "avg_response_length"}
+        assert required.issubset(set(headers))
+
+    def test_export_row_count(self, populated_service):
+        csv_data = populated_service.export_csv()
+        reader = csv.DictReader(io.StringIO(csv_data))
+        rows = list(reader)
+        assert len(rows) == 3
+
+    def test_export_completion_flag(self, populated_service):
+        csv_data = populated_service.export_csv()
+        reader = csv.DictReader(io.StringIO(csv_data))
+        rows = {r["simulation_id"]: r for r in reader}
+        assert rows["s1"]["is_complete"] == "True"
+        assert rows["s3"]["is_complete"] == "False"
+
+    def test_export_empty(self, empty_service):
+        csv_data = empty_service.export_csv()
+        reader = csv.DictReader(io.StringIO(csv_data))
+        assert list(reader) == []


### PR DESCRIPTION
Closes #3

## What
Basic analytics dashboard: derives metrics from live simulation state (completion rate, avg turns, avg response length, daily trends) with a Next.js admin view at `/analytics`, backend `/api/analytics/{summary,trends,export}` endpoints, CSV export, and an entry link on the start screen.

## Tests
- Python: 44 passed, 1 skipped, 8 deselected (CI shape)
- Playwright analytics: 11 passed (new hermetic suite)
- Existing save-resume + mobile: 27 passed, 1 skipped
- `npm run build`: green

## CI
Added analytics regression job to ci.yml (3-job shape preserved, no graph job — repo has no graphify-out).