### PR TITLE
fix #13: /debug/media-check NameError on Mount and StaticFiles

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -4,7 +4,7 @@ API Routes Module
 This module defines the FastAPI routes for the simulation API.
 """
 
-from fastapi import APIRouter, HTTPException, Depends, WebSocket, WebSocketDisconnect
+from fastapi import APIRouter, HTTPException, Depends, Request, WebSocket, WebSocketDisconnect
 from fastapi.responses import JSONResponse, StreamingResponse
 from typing import Dict, Any, List, Optional
 import io
@@ -310,13 +310,15 @@ async def websocket_endpoint(
                 del active_connections[simulation_id]
 
 @router.get("/debug/media-check")
-async def debug_media_check():
+async def debug_media_check(request: Request):
     """
     Debug endpoint to check media directories and files.
     Verifies that media directories exist and lists files in them,
     based on the configuration in api/app.py.
     """
     import os
+    from starlette.routing import Mount
+    from fastapi.staticfiles import StaticFiles
     from api.app import PROJECT_ROOT  # Import PROJECT_ROOT from app.py
     
     # Define base media directory using PROJECT_ROOT
@@ -358,8 +360,8 @@ async def debug_media_check():
     except Exception as e:
         logger.error(f"Error accessing audio directory {audio_dir}: {e}")
 
-    # Check configured media mounts (this part can remain as is)
-    app = router.app 
+    # Check configured media mounts via the running FastAPI app instance.
+    app = request.app
     mounts = []
     static_mounts = {}
     for route in app.routes:

--- a/tests/unit/test_debug_media_check.py
+++ b/tests/unit/test_debug_media_check.py
@@ -1,0 +1,80 @@
+"""
+Regression tests for issue #13: GET /debug/media-check crashed with
+NameError (Mount, StaticFiles not imported) and AttributeError (router.app).
+
+Locks in:
+  - The endpoint returns HTTP 200 without raising.
+  - Response JSON contains checked_directories.videos, checked_directories.audio,
+    found_files, and configured_static_mounts (with audio/video/ui entries).
+"""
+import importlib
+import pytest
+from fastapi.testclient import TestClient
+
+
+def _make_client(monkeypatch, tmp_path):
+    """
+    Reload api.app and return a TestClient.  Use tmp_path so the endpoint's
+    os.makedirs calls land in the temp tree, not in the repo working directory.
+    """
+    # Point PROJECT_ROOT at tmp_path so media dirs are created there.
+    monkeypatch.setenv("PROJECT_ROOT_OVERRIDE", str(tmp_path))
+
+    import api.app as app_mod
+    importlib.reload(app_mod)
+
+    return TestClient(app_mod.app)
+
+
+class TestDebugMediaCheck:
+    """GET /debug/media-check must return 200 with expected structure."""
+
+    def test_returns_200(self, monkeypatch, tmp_path):
+        client = _make_client(monkeypatch, tmp_path)
+        response = client.get("/debug/media-check")
+        assert response.status_code == 200, (
+            f"Expected 200, got {response.status_code}: {response.text}"
+        )
+
+    def test_checked_directories_shape(self, monkeypatch, tmp_path):
+        client = _make_client(monkeypatch, tmp_path)
+        data = client.get("/debug/media-check").json()
+        checked = data["checked_directories"]
+        assert "videos" in checked, "checked_directories must contain 'videos'"
+        assert "audio" in checked, "checked_directories must contain 'audio'"
+
+    def test_found_files_present(self, monkeypatch, tmp_path):
+        client = _make_client(monkeypatch, tmp_path)
+        data = client.get("/debug/media-check").json()
+        assert "found_files" in data, "Response must contain 'found_files'"
+
+    def test_configured_static_mounts_audio(self, monkeypatch, tmp_path):
+        client = _make_client(monkeypatch, tmp_path)
+        data = client.get("/debug/media-check").json()
+        mounts = data.get("configured_static_mounts", {})
+        assert "audio" in mounts, (
+            f"configured_static_mounts must contain 'audio'; got keys: {list(mounts)}"
+        )
+        assert mounts["audio"]["path"] == "/media/audio"
+
+    def test_configured_static_mounts_video(self, monkeypatch, tmp_path):
+        client = _make_client(monkeypatch, tmp_path)
+        data = client.get("/debug/media-check").json()
+        mounts = data.get("configured_static_mounts", {})
+        assert "video" in mounts, (
+            f"configured_static_mounts must contain 'video'; got keys: {list(mounts)}"
+        )
+        assert mounts["video"]["path"] == "/media/videos"
+
+    def test_configured_static_mounts_ui(self, monkeypatch, tmp_path):
+        client = _make_client(monkeypatch, tmp_path)
+        data = client.get("/debug/media-check").json()
+        mounts = data.get("configured_static_mounts", {})
+        assert "ui" in mounts, (
+            f"configured_static_mounts must contain 'ui'; got keys: {list(mounts)}"
+        )
+
+    def test_project_root_present(self, monkeypatch, tmp_path):
+        client = _make_client(monkeypatch, tmp_path)
+        data = client.get("/debug/media-check").json()
+        assert "project_root" in data, "Response must contain 'project_root'"


### PR DESCRIPTION
Closes #13

## What

Fixes `GET /debug/media-check`, which crashed with `NameError` on `Mount`/`StaticFiles` and an `AttributeError` from `router.app` (an `APIRouter` has no `.app`).

- Read the running FastAPI app from Starlette's `request.app` instead of `router.app`
- Lazily import `Mount` (`starlette.routing`) and `StaticFiles` (`fastapi.staticfiles`) inside the endpoint — no import cycle with `api/app.py`
- New regression suite `tests/unit/test_debug_media_check.py` (7 tests): asserts 200 + `checked_directories` / `found_files` / `configured_static_mounts` (audio `/media/audio`, video `/media/videos`, ui) / `project_root` shape via TestClient

## Tests

- `pytest tests/unit/` (with CI's 8-test deselect list): **51 passed, 1 skipped, 8 deselected** (baseline was 44 passed) — 7 new tests all green
- Front end untouched; no e2e changes needed (Python-only fix)