### PR TITLE
fix #16: LLM log callback concurrency bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
           python-version: '3.11'
       - name: Install dependencies
         run: pip install -r requirements.txt
+      - name: Run LLM log routing regression
+        run: pytest tests/unit/test_llm_log_routing_regression.py -q
       - name: Run unit tests
         # Deselect known-broken tests that are tracked by their own open issues
         # (leave them for those issue-workers; don't scope-creep or race them):

--- a/services/llm_service.py
+++ b/services/llm_service.py
@@ -146,13 +146,17 @@ class LLMService:
 
         return self.llm_instances[model_name]
 
-    def set_log_callback(self, callback: Callable[[int, LLMLog],
-                                                  Awaitable[None]]):
+    def set_log_callback(self, callback: Callable[..., Awaitable[None]]):
         """
         Set a callback function for logging LLM interactions.
 
+        The callback receives ``turn_number`` and ``LLMLog`` positionally. When
+        a simulation ID is available, it is supplied as the ``simulation_id``
+        keyword argument so concurrent simulations remain isolated.
+
         Args:
-            callback: An async function that takes a turn number and an LLMLog object
+            callback: An async function that accepts a turn number, an LLMLog,
+                and an optional simulation_id keyword argument.
         """
         self.log_callback = callback
 
@@ -163,7 +167,8 @@ class LLMService:
                               completion: str,
                               parameters: Dict[str, Any] = {},
                               model_name: str = None,
-                              response_time: float = None):
+                              response_time: float = None,
+                              simulation_id: Optional[str] = None):
         """
         Log an LLM interaction if a callback is set.
 
@@ -175,6 +180,7 @@ class LLMService:
             parameters: Additional parameters used in the request
             model_name: The model name used for this operation
             response_time: The response time in seconds
+            simulation_id: The simulation that initiated this interaction
         """
         if self.log_callback:
             log = LLMLog(operation_name=operation_name,
@@ -183,7 +189,14 @@ class LLMService:
                          model_name=model_name or self.default_model_name,
                          parameters=parameters,
                          response_time_seconds=response_time)
-            await self.log_callback(turn_number, log)
+            if simulation_id is None:
+                await self.log_callback(turn_number, log)
+            else:
+                await self.log_callback(
+                    turn_number,
+                    log,
+                    simulation_id=simulation_id,
+                )
             logger.info(
                 f"Logged LLM interaction: {operation_name}{' (Response time: {:.2f}s)'.format(response_time) if response_time else ''}"
             )
@@ -199,6 +212,7 @@ class LLMService:
                 - previous_turn_number: The previous turn number
                 - user_prompt_for_this_turn: Any specific user directions for this turn
                 - max_turns: Maximum number of turns in the simulation (default is 6)
+                - simulation_id: ID of the simulation for log routing
 
         Returns:
             A scenario dictionary with 'id', 'situation_description', 'user_role', 'user_prompt', and 'rationale'
@@ -211,6 +225,7 @@ class LLMService:
                                                 "")
         max_turns = context.get("max_turns", 3)
         difficulty = context.get("difficulty", "normal")
+        simulation_id = context.get("simulation_id")
 
         # For single scenario generation, we set num_ideas to 1
         num_ideas = 1
@@ -345,7 +360,7 @@ class LLMService:
                     num_ideas,
                     "is_final_turn":
                     is_conclusion_generation
-                }, model_used, response_time)
+                }, model_used, response_time, simulation_id=simulation_id)
 
             # Store the scenario in the dictionary
             scenario_id = scenario.get("id")
@@ -377,7 +392,7 @@ class LLMService:
                 num_ideas,
                 "is_final_turn":
                 is_conclusion_generation
-            }, model_used, response_time)
+            }, model_used, response_time, simulation_id=simulation_id)
 
         # Parse the JSON result into a list of scenario dictionaries
         scenarios = self._parse_json_scenarios(result, current_turn_number)
@@ -403,7 +418,8 @@ class LLMService:
 
     async def create_video_prompt(self,
                                   scenario: Dict[str, str],
-                                  turn_number: int = 1) -> List[str]:
+                                  turn_number: int = 1,
+                                  simulation_id: Optional[str] = None) -> List[str]:
         """
         Generate a video generation prompt from the scenario details,
         parse it, and return a list of scene descriptions.
@@ -411,6 +427,7 @@ class LLMService:
         Args:
             scenario: The scenario dictionary with 'situation_description'
             turn_number: The current turn number for logging
+            simulation_id: The simulation that initiated this interaction
 
         Returns:
             A list of four scene descriptions. Returns an empty list if parsing fails.
@@ -447,7 +464,8 @@ class LLMService:
             # Log the interaction
             await self.log_interaction(turn_number, "create_video_prompt_llm_call",
                                        formatted_prompt, raw_llm_output, {},
-                                       model_used, response_time)
+                                       model_used, response_time,
+                                       simulation_id=simulation_id)
 
             # Attempt to parse JSON, trying to extract from markdown if necessary
             parsed_json = None
@@ -477,7 +495,8 @@ class LLMService:
                         f"Invalid JSON structure. Raw: {raw_llm_output[:500]}. Extracted/Processed: {json_str[:500]}. Parsed: {str(parsed_json)[:200]}",
                         {},
                         model_used,
-                        response_time
+                        response_time,
+                        simulation_id=simulation_id,
                     )
                     return [] # Return empty list on structure error
 
@@ -492,7 +511,8 @@ class LLMService:
                     f"JSONDecodeError: {str(e)} - Raw: {raw_llm_output[:1000]} - Processed: {json_str[:3500]}",
                     {},
                     model_used,
-                    response_time
+                    response_time,
+                    simulation_id=simulation_id,
                 )
                 return [] # Return empty list on JSON decode error
 
@@ -508,7 +528,8 @@ class LLMService:
                 f"LLM Error: {str(e)}",
                 {},
                 model_used,
-                response_time # Can still log time if failure happened after start
+                response_time, # Can still log time if failure happened after start
+                simulation_id=simulation_id,
             )
             return [] # Return empty list on LLM call failure
 

--- a/services/simulation_service.py
+++ b/services/simulation_service.py
@@ -49,29 +49,36 @@ class SimulationService:
         # Set up the logging callback for the LLM service
         self.llm_service.set_log_callback(self._log_llm_interaction)
 
-    async def _log_llm_interaction(self, turn_number: int, llm_log: LLMLog) -> None:
+    async def _log_llm_interaction(
+        self,
+        turn_number: int,
+        llm_log: LLMLog,
+        simulation_id: Optional[str] = None,
+    ) -> None:
         """
-        Callback for logging LLM interactions.
+        Store an LLM interaction on its owning simulation.
 
         Args:
             turn_number: The turn number the log belongs to
             llm_log: The LLM log to store
+            simulation_id: ID of the simulation that initiated the LLM call
         """
-        # Find the simulation that's currently being processed
-        # This is a simplification - in a real system, we'd need to track which simulation
-        # is associated with each LLM call
-        simulations = self.state_service.get_all_simulations()
-        if not simulations:
-            logger.warning("No simulations found for LLM log")
+        if not simulation_id:
+            logger.warning("Missing simulation ID for LLM log")
             return
 
-        # For now, we'll log to the most recently created simulation
-        simulations.sort(key=lambda s: s.created_at, reverse=True)
-        simulation = simulations[0]
+        simulation = self.state_service.get_simulation(simulation_id)
+        if not simulation:
+            logger.warning("Simulation %s not found for LLM log", simulation_id)
+            return
 
         # Only log if developer mode is enabled
         if simulation.developer_mode:
-            logger.info(f"Logging LLM interaction for simulation {simulation.simulation_id}, turn {turn_number}")
+            logger.info(
+                "Logging LLM interaction for simulation %s, turn %s",
+                simulation.simulation_id,
+                turn_number,
+            )
             simulation.add_llm_log(turn_number, llm_log)
             self.state_service.update_simulation(simulation)
 
@@ -118,7 +125,8 @@ class SimulationService:
                 "previous_turn_number": 0,
                 "user_prompt_for_this_turn": initial_prompt or "",
                 "max_turns": simulation.max_turns,
-                "difficulty": simulation.difficulty.value
+                "difficulty": simulation.difficulty.value,
+                "simulation_id": simulation.simulation_id
             }
 
             # Generate a single scenario
@@ -155,7 +163,11 @@ class SimulationService:
                 simulation.select_scenario(1, scenario_id)
 
                 # Generate media prompts - video prompt only
-                video_prompt = await self.llm_service.create_video_prompt(scenario, turn_number=1)
+                video_prompt = await self.llm_service.create_video_prompt(
+                    scenario,
+                    turn_number=1,
+                    simulation_id=simulation.simulation_id,
+                )
 
                 # Add media prompts to the simulation state - set narration_script to None
                 simulation.add_media_prompts(1, video_prompt, None)
@@ -246,7 +258,8 @@ class SimulationService:
                     "previous_turn_number": current_turn - 1,
                     "user_prompt_for_this_turn": user_response,  # Pass the user's final response
                     "max_turns": simulation.max_turns,
-                    "difficulty": simulation.difficulty.value
+                    "difficulty": simulation.difficulty.value,
+                    "simulation_id": simulation.simulation_id
                 }
 
                 logger.info(f"[CONCLUSION] Context prepared: turn={context['current_turn_number']}, has_user_prompt={bool(context['user_prompt_for_this_turn'])}")
@@ -274,7 +287,8 @@ class SimulationService:
                         "previous_turn_number": current_turn - 1,
                         "user_prompt_for_this_turn": user_response,
                         "max_turns": simulation.max_turns,
-                        "difficulty": simulation.difficulty.value
+                        "difficulty": simulation.difficulty.value,
+                        "simulation_id": simulation.simulation_id
                     }
                     logger.info(f"[CONCLUSION] Forced conclusion generation due to turn overflow")
                 else:
@@ -287,7 +301,8 @@ class SimulationService:
                         "previous_turn_number": current_turn,
                         "user_prompt_for_this_turn": "", # Default for regular next turn
                         "max_turns": simulation.max_turns,
-                        "difficulty": simulation.difficulty.value
+                        "difficulty": simulation.difficulty.value,
+                        "simulation_id": simulation.simulation_id
                     }
                     # is_complete remains False
 
@@ -356,7 +371,11 @@ class SimulationService:
                 simulation.select_scenario(storage_turn, scenario_id)
 
                 # Generate media prompts - video prompt only
-                video_prompt = await self.llm_service.create_video_prompt(scenario, turn_number=storage_turn)
+                video_prompt = await self.llm_service.create_video_prompt(
+                    scenario,
+                    turn_number=storage_turn,
+                    simulation_id=simulation.simulation_id,
+                )
 
                 # Add media prompts to the simulation state - set narration_script to None
                 simulation.add_media_prompts(storage_turn, video_prompt, None)

--- a/tests/unit/test_llm_log_routing_regression.py
+++ b/tests/unit/test_llm_log_routing_regression.py
@@ -1,0 +1,123 @@
+"""Regression tests for issue #16: LLM logs must stay with their simulation."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from models.simulation import LLMLog, SimulationState
+from services.llm_service import LLMService
+from services.simulation_service import SimulationService
+from services.state_service import StateService
+
+
+class RecordingLLMService:
+    """Minimal LLM seam for checking simulation context propagation."""
+
+    def __init__(self):
+        self.idea_contexts = []
+        self.video_simulation_ids = []
+
+    def set_log_callback(self, callback):
+        self.log_callback = callback
+
+    async def create_idea(self, context):
+        self.idea_contexts.append(context)
+        return {
+            "id": "scenario_1_1",
+            "situation_description": "Test crisis",
+            "rationale": "test",
+            "user_role": "Director",
+            "user_prompt": "Act now",
+        }
+
+    async def create_video_prompt(self, scenario, turn_number=1, simulation_id=None):
+        self.video_simulation_ids.append(simulation_id)
+        return ["scene 1", "scene 2", "scene 3", "scene 4"]
+
+
+class FakeMediaService:
+    async def generate_media_parallel(self, scenario, video_prompt, turn=1):
+        return {"video_urls": ["https://example.com/video.mp4"], "audio_url": None}
+
+
+def make_log(operation_name):
+    return LLMLog(
+        operation_name=operation_name,
+        prompt=f"prompt for {operation_name}",
+        completion=f"completion for {operation_name}",
+        model_name="test-model",
+    )
+
+
+@pytest.mark.asyncio
+async def test_llm_log_callback_routes_interleaved_logs_by_simulation_id():
+    """Concurrent callbacks must never select a different simulation by recency."""
+    state_service = StateService()
+    simulation_a = state_service.create_simulation(SimulationState(developer_mode=True))
+    simulation_b = state_service.create_simulation(SimulationState(developer_mode=True))
+    llm_service = MagicMock()
+    SimulationService(
+        llm_service=llm_service,
+        state_service=state_service,
+        media_service=MagicMock(),
+    )
+    callback = llm_service.set_log_callback.call_args.args[0]
+
+    await asyncio.gather(
+        callback(1, make_log("simulation-a"), simulation_id=simulation_a.simulation_id),
+        callback(1, make_log("simulation-b"), simulation_id=simulation_b.simulation_id),
+    )
+
+    assert [log.operation_name for log in simulation_a.turns[0].llm_logs] == ["simulation-a"]
+    assert [log.operation_name for log in simulation_b.turns[0].llm_logs] == ["simulation-b"]
+
+
+@pytest.mark.asyncio
+async def test_llm_service_passes_simulation_id_to_log_callback():
+    """LLMService must forward the request's simulation ID to the callback."""
+    llm_service = object.__new__(LLMService)
+    llm_service.default_model_name = "test-model"
+    llm_service.log_callback = AsyncMock()
+
+    await llm_service.log_interaction(
+        1,
+        "create_idea",
+        "prompt",
+        "completion",
+        simulation_id="sim_a",
+    )
+
+    llm_service.log_callback.assert_awaited_once()
+    assert llm_service.log_callback.await_args.kwargs["simulation_id"] == "sim_a"
+
+
+@pytest.mark.asyncio
+async def test_simulation_service_propagates_simulation_id_to_llm_calls():
+    """Every LLM request created for a simulation carries its stable ID."""
+    llm_service = RecordingLLMService()
+    state_service = StateService()
+    simulation_service = SimulationService(
+        llm_service=llm_service,
+        state_service=state_service,
+        media_service=FakeMediaService(),
+    )
+
+    simulation = await simulation_service.create_new_simulation(
+        initial_prompt="Test prompt",
+        developer_mode=True,
+    )
+
+    assert llm_service.idea_contexts[0]["simulation_id"] == simulation.simulation_id
+    assert llm_service.video_simulation_ids == [simulation.simulation_id]
+
+    await simulation_service.process_user_response(simulation.simulation_id, "Next answer")
+
+    assert [context["simulation_id"] for context in llm_service.idea_contexts] == [
+        simulation.simulation_id,
+        simulation.simulation_id,
+    ]
+    assert llm_service.video_simulation_ids == [
+        simulation.simulation_id,
+        simulation.simulation_id,
+    ]


### PR DESCRIPTION
## Summary
- route LLM interaction logs by the originating simulation ID instead of newest simulation
- propagate the ID through initial and follow-up LLM/video-prompt requests
- add an interleaved callback regression suite and an explicit CI step

## Verification
- Python unit suite: 151 passed, 1 skipped, 8 deselected
- LLM log routing regression: 3 passed
- Playwright Chromium regressions: 45 passed
- Playwright mobile regressions: 8 passed
- `npm run build` passed
- no graph refresh applicable: this repository has no `graphify-out/`, `.mcp.json`, or code-graph job

Closes #16
