### PR TITLE
fix #20: [11] `requirements-prod.txt` and `requirements.txt` differ by 20 major versions on critical packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
         run: pytest tests/unit/test_dead_code_removal_regression.py -q
       - name: Run WebSocket cleanup regression
         run: pytest tests/unit/test_ws_cleanup_regression.py -q
+      - name: Run requirements alignment regression
+        run: pytest tests/unit/test_requirements_alignment.py -q
       - name: Run unit tests
         # Deselect known-broken tests that are tracked by their own open issues
         # (leave them for those issue-workers; don't scope-creep or race them):

--- a/env.example
+++ b/env.example
@@ -1,14 +1,7 @@
 # API KEYS
-OPENAI_API_KEY=your_openai_api_key
 GROQ_API_KEY=your_groq_api_key_here
 HUGGINGFACE_API_KEY=your_huggingface_api_key_here  # Required for fal-ai text-to-video generation and Dia-TTS audio narration
 GOOGLE_API_KEY=your_google_api_key_here  # For Gemini 2.5 Flash model
-
-# REDIS CONFIGURATION
-REDIS_HOST=localhost
-REDIS_PORT=6379
-REDIS_PASSWORD=your_redis_password_here
-REDIS_DB=0
 
 # APPLICATION SETTINGS
 APP_HOST=0.0.0.0

--- a/requirements-prod.txt
+++ b/requirements-prod.txt
@@ -1,12 +1,24 @@
-fastapi>=0.115.5
-uvicorn>=0.32.1
+# Production runtime dependencies.
+#
+# This is the runtime subset of requirements.txt: every shared package MUST use
+# the exact same version specifier as requirements.txt (one coherent, reproducible
+# dependency contract). The only intentional difference is that this file omits
+# test-only tooling that production never imports: pytest, pytest-asyncio, httpx.
+#
+# tests/unit/test_requirements_alignment.py enforces this alignment and fails if
+# the two files drift, or if removed packages (redis, google-generativeai,
+# langchain-openai) return.
+fastapi==0.115.5
+uvicorn==0.32.1
 python-dotenv==1.0.0
-requests>=2.32.3
-aiohttp>=3.13.3
-groq==0.4.1
-pydantic==2.6.0
-redis==5.0.1
-google-generativeai==0.3.2
+requests==2.32.3
+aiohttp==3.13.3
+groq==0.24.0
+pydantic==2.11.3
 huggingface_hub[inference,cli]>=0.21.0
 boto3==1.34.36
-python-multipart>=0.0.18 
+python-multipart>=0.0.18
+langchain==0.2.17
+langchain-core==0.2.43
+langchain-groq==0.1.10
+langchain-text-splitters==0.2.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ requests==2.32.3
 aiohttp==3.13.3
 groq==0.24.0
 pydantic==2.11.3
-redis==5.0.1
 huggingface_hub[inference,cli]>=0.21.0
 boto3==1.34.36
 python-multipart>=0.0.18
@@ -14,6 +13,5 @@ pytest-asyncio==0.23.4
 langchain==0.2.17
 langchain-core==0.2.43
 langchain-groq==0.1.10
-langchain-openai==0.1.25
 langchain-text-splitters==0.2.4
 httpx==0.27.0

--- a/tests/unit/test_requirements_alignment.py
+++ b/tests/unit/test_requirements_alignment.py
@@ -1,0 +1,194 @@
+"""
+Regression tests for issue #20: requirements.txt and requirements-prod.txt
+diverged by many major versions on critical packages, and prod carried
+obsolete/unused deps (redis, google-generativeai, langchain-openai).
+
+These tests are hermetic: pure file parsing with the standard library only.
+They do NOT import the app and never touch the network. They lock in that the
+two requirement files stay one coherent dependency contract, that removed
+packages never return, and that env.example no longer advertises unused config.
+"""
+import re
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REQUIREMENTS = REPO_ROOT / "requirements.txt"
+REQUIREMENTS_PROD = REPO_ROOT / "requirements-prod.txt"
+ENV_EXAMPLE = REPO_ROOT / "env.example"
+
+# Packages that must never reappear in EITHER requirements file.
+OBSOLETE_PACKAGES = ["redis", "google-generativeai", "langchain-openai"]
+
+# Runtime deps that prod MUST ship so it does not ImportError at boot.
+REQUIRED_PROD_PACKAGES = [
+    "groq",
+    "langchain",
+    "langchain-groq",
+    "langchain-core",
+    "langchain-text-splitters",
+    "fastapi",
+    "uvicorn",
+    "pydantic",
+    "boto3",
+    "huggingface_hub",
+    "python-multipart",
+    "python-dotenv",
+    "requests",
+    "aiohttp",
+]
+
+# The only intentional dev-only difference: test tooling prod never imports.
+TEST_ONLY_PACKAGES = {"pytest", "pytest-asyncio", "httpx"}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _canonicalize(name: str) -> str:
+    """PEP 503 canonical form: lowercase, collapse runs of -/_/. to a single -."""
+    return re.sub(r"[-_.]+", "-", name.strip().lower())
+
+
+def _split_name_and_spec(requirement: str):
+    """
+    Split a requirement line into (bare_name, extras, version_spec).
+
+    Given ``huggingface_hub[inference,cli]>=0.21.0`` returns
+    ``("huggingface_hub", "[inference,cli]", ">=0.21.0")``.
+    """
+    # Strip inline comments and surrounding whitespace.
+    line = requirement.split("#", 1)[0].strip()
+    # Name is everything up to the first version operator or extras bracket.
+    m = re.match(r"^([A-Za-z0-9][A-Za-z0-9._-]*)(\[[^\]]*\])?(.*)$", line)
+    assert m, f"Could not parse requirement line: {requirement!r}"
+    bare_name = m.group(1)
+    extras = m.group(2) or ""
+    version_spec = m.group(3).strip()
+    return bare_name, extras, version_spec
+
+
+def _parse_requirements(path: Path):
+    """
+    Parse a requirements file into a dict of
+    {canonical_name: full_spec_string} where full_spec_string preserves
+    extras + version specifier (so an extras mismatch is caught) but the KEY
+    excludes the extras bracket.
+    """
+    assert path.exists(), f"Missing requirements file: {path}"
+    result = {}
+    for raw in path.read_text().splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if not line:
+            continue
+        bare_name, extras, version_spec = _split_name_and_spec(line)
+        canonical = _canonicalize(bare_name)
+        full_spec = f"{extras}{version_spec}"
+        result[canonical] = full_spec
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / module-level parses
+# ---------------------------------------------------------------------------
+
+DEV = _parse_requirements(REQUIREMENTS)
+PROD = _parse_requirements(REQUIREMENTS_PROD)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("package", OBSOLETE_PACKAGES)
+def test_obsolete_package_absent_from_dev(package):
+    canonical = _canonicalize(package)
+    assert canonical not in DEV, (
+        f"Obsolete package {package!r} must not be in requirements.txt "
+        f"(it is unused / was removed for issue #20)."
+    )
+
+
+@pytest.mark.parametrize("package", OBSOLETE_PACKAGES)
+def test_obsolete_package_absent_from_prod(package):
+    canonical = _canonicalize(package)
+    assert canonical not in PROD, (
+        f"Obsolete package {package!r} must not be in requirements-prod.txt "
+        f"(it is unused / was removed for issue #20)."
+    )
+
+
+def test_shared_packages_have_identical_specs():
+    """Core regression: any package in BOTH files must pin the same spec."""
+    shared = sorted(set(DEV) & set(PROD))
+    assert shared, "Expected overlapping packages between dev and prod files."
+    mismatches = {
+        name: (DEV[name], PROD[name])
+        for name in shared
+        if DEV[name] != PROD[name]
+    }
+    assert not mismatches, (
+        "requirements.txt and requirements-prod.txt disagree on version "
+        f"specifiers for shared packages: {mismatches}. They must be identical."
+    )
+
+
+def test_prod_is_name_subset_of_dev():
+    """No prod-only package: every prod package must exist in dev."""
+    prod_only = sorted(set(PROD) - set(DEV))
+    assert not prod_only, (
+        f"requirements-prod.txt contains packages absent from requirements.txt: "
+        f"{prod_only}. Prod must be a strict subset of dev."
+    )
+
+
+@pytest.mark.parametrize("package", REQUIRED_PROD_PACKAGES)
+def test_required_runtime_package_present_in_prod(package):
+    canonical = _canonicalize(package)
+    assert canonical in PROD, (
+        f"Runtime dependency {package!r} is missing from requirements-prod.txt; "
+        f"production would ImportError without it."
+    )
+
+
+def test_only_test_tooling_is_dev_only():
+    """Locks the intentional difference: dev - prod == the test tools exactly."""
+    dev_only = set(DEV) - set(PROD)
+    expected = {_canonicalize(p) for p in TEST_ONLY_PACKAGES}
+    assert dev_only == expected, (
+        f"Packages present in dev but not prod must be exactly the test-only "
+        f"tools {sorted(expected)}, but got {sorted(dev_only)}. A runtime dep may "
+        f"have gone missing from prod (or a new test tool leaked in)."
+    )
+
+
+def test_env_example_has_no_openai_key():
+    assert ENV_EXAMPLE.exists(), f"Missing env.example: {ENV_EXAMPLE}"
+    offending = [
+        line
+        for line in ENV_EXAMPLE.read_text().splitlines()
+        if re.match(r"^\s*OPENAI_API_KEY\s*=", line)
+    ]
+    assert not offending, (
+        f"env.example must not define OPENAI_API_KEY (unused): {offending}"
+    )
+
+
+def test_env_example_has_no_redis_config():
+    assert ENV_EXAMPLE.exists(), f"Missing env.example: {ENV_EXAMPLE}"
+    offending = [
+        line
+        for line in ENV_EXAMPLE.read_text().splitlines()
+        if re.match(r"^\s*REDIS_", line)
+    ]
+    assert not offending, (
+        f"env.example must not define any REDIS_* variable (Redis is unused): "
+        f"{offending}"
+    )


### PR DESCRIPTION
Closes #20

## Problem
`requirements.txt` and `requirements-prod.txt` diverged by major versions on critical packages: `groq` 0.4.1 (prod) vs 0.24.0 (dev), `pydantic` 2.6.0 (prod) vs 2.11.3 (dev). Prod also carried obsolete `google-generativeai==0.3.2` (Gemini was removed) and `redis==5.0.1` (never used). Worse, **prod omitted the entire `langchain` family** that `services/llm_service.py` and `services/simulation_service.py` import — so a prod install that "works in dev" would `ImportError` at boot.

## Fix — one coherent, reproducible dependency contract
- **`requirements-prod.txt`**: every shared package now pins the exact same version as `requirements.txt` (`groq 0.4.1→0.24.0`, `pydantic 2.6.0→2.11.3`, `fastapi`/`uvicorn`/`requests`/`aiohttp` `>=`→`==`). Added the runtime langchain deps that were missing (`langchain`, `langchain-core`, `langchain-groq`, `langchain-text-splitters`). Removed `google-generativeai` and `redis`. Prod = runtime subset of dev, omitting only test tooling (`pytest`, `pytest-asyncio`, `httpx`).
- **`requirements.txt`**: removed `redis` and `langchain-openai` (0 imports anywhere).
- **`env.example`**: removed `OPENAI_API_KEY` (0 code usage) and the `REDIS_*` block (unused). Kept `GOOGLE_API_KEY` — still read by `api/app.py` init and documented in README (out of scope to remove; not requested by the issue).

### Investigation (imports verified, not assumed)
- Used at runtime: `langchain`/`langchain_groq` (llm_service, simulation_service), `groq` (groq_tts_service, llm_service), plus fastapi/uvicorn/pydantic/boto3/aiohttp/requests/huggingface_hub/python-multipart/python-dotenv.
- 0 imports: `redis`, `langchain-openai`. `google-generativeai` not imported (only commented-out Gemini code; the `tests/test_gemini.py` fossil imports the *different* `google.genai`/`google.adk` packages and is not CI-collected). Left the pre-existing fossil/docs untouched to avoid scope creep.

## New regression coverage
`tests/unit/test_requirements_alignment.py` — hermetic (stdlib + pytest only, no network, no app import). Fails if:
- the two files diverge on any shared package's version specifier,
- an obsolete package (`redis`/`google-generativeai`/`langchain-openai`) returns to either file,
- a runtime dep drops out of prod (`dev - prod == {pytest, pytest-asyncio, httpx}` exactly),
- `env.example` regains `OPENAI_API_KEY` or any `REDIS_*` var.

## CI
Added a named "Run requirements alignment regression" step to the `unit-tests` job. Repo's 3-job shape preserved (`unit-tests`, `regressions`, `build`) — no code-graph job (repo has no `graphify-out/`).

## Files changed
- `requirements.txt`
- `requirements-prod.txt`
- `env.example`
- `tests/unit/test_requirements_alignment.py` (new)
- `.github/workflows/ci.yml`

## Tests / checks (local)
- Python unit (CI-equivalent, 8 deselects): **209 passed, 1 skipped, 8 deselected** (was 184 baseline; +25 new).
- New regression alone: **25 passed**; negative sanity check confirmed it fails when divergence/obsolete entries are reinjected.
- Runtime import smoke: `langchain, langchain_groq, groq, fastapi, pydantic, boto3, aiohttp, requests` all import OK.
- Next.js `npm run build`: **success**.

## Four-subagent pipeline outcomes
1. **Implementation + CI**: reconciled files, new regression, CI step. No commit.
2. **Code review** (mattpocock): 0 blockers, 2 benign nits (langchain ordering; explicit transitive pin). Adversarially confirmed the regression catches every divergence/obsolete/drop scenario.
3. **Code simplifier**: one safe no-op removal in the test (`{n for n in X}` → `X`); tests unchanged at 25 passed.
4. **Security** (claude-security scan-changes): **no blocking findings; net security improvement** (removes stale prod pins, shrinks attack surface). Secrets/CI-injection/test-file/availability all clean. INFO: `python-multipart`/`huggingface_hub` keep aligned `>=` floors (both fixed above known-CVE floors); optional `pip-audit` suggested. Live CVE DB lookup was unavailable this session.

Graph status: repo has no `graphify-out/` and no code-graph CI job — none added.

_Claude did not merge; Hermes owns merge after fail-closed CI verification._
