### PR TITLE
fix #25: [16] print() debugging statements bypass structured logging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,8 @@ jobs:
         run: pytest tests/unit/test_nested_test_discovery_regression.py -q
       - name: Run LLMChain LCEL migration regression
         run: pytest tests/unit/test_llmchain_lcel_migration_regression.py -q
+      - name: Run print/logging regression
+        run: pytest tests/unit/test_no_print_media_service_regression.py -q
       - name: Run unit tests
         # Deselect known-broken tests that are tracked by their own open issues
         # (leave them for those issue-workers; don't scope-creep or race them).

--- a/tests/unit/test_no_print_media_service_regression.py
+++ b/tests/unit/test_no_print_media_service_regression.py
@@ -1,0 +1,75 @@
+"""
+Regression tests for issue #25 ("[16] `print()` debugging statements bypass
+structured logging").
+
+The original report cited seven ``print()`` calls in
+``services/media_service.py`` (lines 643, 659, 670, 679, 681, 684, 687) inside
+``generate_media_for_turn``. ``print()`` bypasses the configured ``logging``
+system, ignores log levels, and is invisible to log aggregation.
+
+Finding: that entire method (and all seven ``print()`` calls) was already
+deleted by fix #18 (commit 1b7a376 / PR #40), so the module already satisfies
+#25. The #18 regression only asserts the *method* is gone -- nothing guards the
+acceptance criterion of #25 itself (no ``print()`` bypassing structured
+logging). These tests are that missing recurrence guard: they will fail the
+moment any ``print(...)`` is reintroduced into ``services/media_service.py``.
+
+We parse the module source with the stdlib ``ast`` module rather than grepping
+for the substring ``"print"`` so that occurrences inside strings, comments, or
+identifiers like ``pprint``/``fingerprint`` never produce false positives.
+"""
+import ast
+import logging
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MEDIA_SERVICE_PY = REPO_ROOT / "services" / "media_service.py"
+
+
+def _print_call_line_numbers(source: str) -> list[int]:
+    """Return the line numbers of every bare ``print(...)`` call in *source*.
+
+    Only ``ast.Call`` nodes whose callable is the built-in name ``print`` are
+    counted, so string/comment occurrences of the word "print" are ignored.
+    """
+    tree = ast.parse(source)
+    lines: list[int] = []
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "print"
+        ):
+            lines.append(node.lineno)
+    return sorted(lines)
+
+
+class TestNoPrintInMediaService:
+    """Lock in that media_service.py logs via ``logging``, never ``print()``."""
+
+    def test_no_print_calls_in_media_service(self):
+        """Zero ``print(...)`` calls may exist in services/media_service.py."""
+        source = MEDIA_SERVICE_PY.read_text()
+        offending = _print_call_line_numbers(source)
+        assert offending == [], (
+            "services/media_service.py must not use print() (issue #25); "
+            "print() bypasses structured logging. Found print() calls at "
+            f"line(s): {offending}. Use logger.info()/error()/debug() instead."
+        )
+
+    def test_module_configures_module_level_logger(self):
+        """Positive control: the module wires up a stdlib ``logging`` logger."""
+        source = MEDIA_SERVICE_PY.read_text()
+        assert "logging.getLogger(__name__)" in source, (
+            "services/media_service.py must configure a module-level logger via "
+            "logging.getLogger(__name__) so structured logging is available."
+        )
+
+    def test_logger_object_is_a_logging_logger(self):
+        """The imported ``logger`` really is a ``logging.Logger`` instance."""
+        from services import media_service
+
+        assert isinstance(media_service.logger, logging.Logger), (
+            "services.media_service.logger must be a logging.Logger instance."
+        )


### PR DESCRIPTION
Closes #25

## Summary

Issue #25 reported seven `print()` calls in `services/media_service.py` inside `generate_media_for_turn`, which bypass the configured `logging` system (invisible to log levels and log aggregation).

**Verified current state:** that entire method — and all seven `print()` calls — was already removed by fix #18 (commit `1b7a376` / PR #40). Current `services/media_service.py` (614 lines) has **zero** `print(` calls and configures `logger = logging.getLogger(__name__)`. The module already satisfies #25, so no logging change is invented here.

The gap that remained: the #18 regression only asserts the dead *method* is absent — nothing guarded #25's own acceptance criterion (no `print()` bypassing structured logging). This PR adds that missing **recurrence guard**.

## Changes

- **`tests/unit/test_no_print_media_service_regression.py`** (new) — AST-based regression: parses `services/media_service.py` and asserts zero `print(...)` calls by walking `ast.Call` nodes whose `func` is the builtin name `print` (so `"print"` inside strings/comments and identifiers like `pprint` never false-positive). Failure message lists offending line numbers. Includes a positive control that the module configures a `logging.getLogger(__name__)` logger and that `media_service.logger` is a real `logging.Logger`. Fails the moment any `print()` is reintroduced.
- **`.github/workflows/ci.yml`** — adds a named `Run print/logging regression` step in the `unit-tests` job, matching the sibling per-issue regression steps.

`services/media_service.py` is intentionally unchanged (already correct). No application behavior changes.

## Pipeline

Four fresh subagents ran sequentially in this checkout: implementation+CI, code-review (APPROVE), code-simplifier (no changes — already minimal), security-review (CLEAN — test-only/CI-only, no new trust boundary, `ast.parse` does not execute code, no `pull_request_target`).

## Local gates

- Python unit suite (exact CI deselects): **248 passed, 1 skipped, 6 deselected** (245 baseline + 3 new tests).
- Next.js production build (`npm run build`): **pass**.
- Playwright e2e: not impacted by this diff (no frontend/app code touched); runs in CI on this PR.
- Graph refresh: **N/A** — repo has no `graphify-out/` and no code-graph CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
